### PR TITLE
Add style loader when CSS loader is used

### DIFF
--- a/src/loadersToDependencies.js
+++ b/src/loadersToDependencies.js
@@ -28,6 +28,7 @@ module.exports = function (loaders) {
     }
 
     if (loader === 'css') {
+      depLoaders['style-loader'] = '^0.13.0';
       depLoaders['css-loader'] = '^0.23.1';
     }
 


### PR DESCRIPTION
I've taken the version of `style-loader` that's in `package.json`. Without this change, the project ZIP isn't runnable when you're importing CSS files - it complains about the lack of `style-loader`, and I can see in the codebase that whenever the `css-loader` is used, you also add `style-loader`, so I think this was the right place to modify 😅